### PR TITLE
Call backends asynchronously

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/crossplane/provider-ceph/apis"
 	"github.com/crossplane/provider-ceph/apis/v1alpha1"
+	"github.com/crossplane/provider-ceph/internal/backendstore"
 	ceph "github.com/crossplane/provider-ceph/internal/controller"
 	"github.com/crossplane/provider-ceph/internal/controller/features"
 )
@@ -178,6 +179,7 @@ func main() {
 		})), "cannot create default store config")
 	}
 
-	kingpin.FatalIfError(ceph.Setup(mgr, o), "Cannot setup Ceph controllers")
+	backendStore := backendstore.NewBackendStore()
+	kingpin.FatalIfError(ceph.Setup(mgr, o, backendStore), "Cannot setup Ceph controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.19.1
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -607,6 +607,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -48,8 +48,13 @@ func (b *BackendStore) GetBackend(backendName string) *s3.Client {
 func (b *BackendStore) GetAllBackends() s3Backends {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	// Create a new s3Backends to hold a copy of the backends
+	backends := make(s3Backends, len(b.s3Backends))
+	for k, v := range b.s3Backends {
+		backends[k] = v
+	}
 
-	return b.s3Backends
+	return backends
 }
 
 func (b *BackendStore) GetBackendStore() *BackendStore {

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -11,7 +11,7 @@ type s3Backends map[string]*s3.Client
 
 // BackendStore stores the active s3 backends.
 type BackendStore struct {
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	s3Backends s3Backends
 }
 
@@ -36,8 +36,8 @@ func (b *BackendStore) AddOrUpdateBackend(backendName string, backendClient *s3.
 }
 
 func (b *BackendStore) GetBackend(backendName string) *s3.Client {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	if backend, ok := b.s3Backends[backendName]; ok {
 		return backend
 	}

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -1,0 +1,67 @@
+package backendstore
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// s3Backends is a map of S3 backend name (eg ceph cluster name) to S3 client.
+type s3Backends map[string]*s3.Client
+
+// BackendStore stores the active s3 backends.
+type BackendStore struct {
+	mu         sync.Mutex
+	s3Backends s3Backends
+}
+
+func NewBackendStore() *BackendStore {
+	return &BackendStore{
+		s3Backends: make(s3Backends),
+	}
+}
+
+func (b *BackendStore) DeleteBackend(backendName string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.s3Backends, backendName)
+}
+
+func (b *BackendStore) AddOrUpdateBackend(backendName string, backendClient *s3.Client) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.s3Backends[backendName] = backendClient
+}
+
+func (b *BackendStore) GetBackend(backendName string) *s3.Client {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if backend, ok := b.s3Backends[backendName]; ok {
+		return backend
+	}
+
+	return nil
+}
+
+func (b *BackendStore) GetAllBackends() s3Backends {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.s3Backends
+}
+
+func (b *BackendStore) GeBackendStore() *BackendStore {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b
+}
+
+func (b *BackendStore) BackendsAreStored() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return len(b.s3Backends) != 0
+}

--- a/internal/backendstore/backendstore.go
+++ b/internal/backendstore/backendstore.go
@@ -52,7 +52,7 @@ func (b *BackendStore) GetAllBackends() s3Backends {
 	return b.s3Backends
 }
 
-func (b *BackendStore) GeBackendStore() *BackendStore {
+func (b *BackendStore) GetBackendStore() *BackendStore {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -329,13 +329,11 @@ func (c *external) delete(ctx context.Context, bucketName string, s3Backend *s3.
 	if err != nil {
 		var noSuchBucketErr *s3types.NotFound
 		if errors.As(err, &noSuchBucketErr) {
-			return nil
+			return errors.Wrap(err, errDeleteBucket)
 		}
-
-		return errors.Wrap(err, errDeleteBucket)
 	}
 
-	return nil
+	return err
 }
 
 func (c *external) deleteAll(ctx context.Context, bucketName string) error {

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -30,6 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -82,6 +83,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore)
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: newNoOpService,
 			backendStore: s,
+			log:          o.Logger.WithValues("controller", name),
 		}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -101,6 +103,7 @@ type connector struct {
 	usage        resource.Tracker
 	newServiceFn func(creds []byte) (interface{}, error)
 	backendStore *backendstore.BackendStore
+	log          logging.Logger
 }
 
 // Connect typically produces an ExternalClient by:
@@ -120,6 +123,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 // external resource to ensure it reflects the managed resource's desired state.
 type external struct {
 	backendStore *backendstore.BackendStore
+	log          logging.Logger
 }
 
 func (c *external) bucketExists(ctx context.Context, s3BackendName, bucketName string) (bool, error) {
@@ -249,6 +253,8 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}
+
+		c.log.Info("Creating bucket on single s3 backend", "backend name", cr.GetProviderConfigReference().Name)
 		_, err = s3Backend.CreateBucket(ctx, s3internal.BucketToCreateBucketInput(cr))
 		if err != nil {
 			return managed.ExternalCreation{}, errors.Wrap(err, errCreateBucket)
@@ -261,12 +267,13 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		}, nil
 	}
 
-	// No ProviderConfigReference Name specified for bucket, we can infer that his bucket is to
+	// No ProviderConfigReference Name specified for bucket, we can infer that this bucket is to
 	// be created on all S3 Backends.
 	if !c.backendStore.BackendsAreStored() {
 		return managed.ExternalCreation{}, errors.New(errNoS3BackendsStored)
 	}
 
+	c.log.Info("Creating bucket on all available s3 backends")
 	for _, client := range c.backendStore.GetAllBackends() {
 		_, err := client.CreateBucket(ctx, s3internal.BucketToCreateBucketInput(cr))
 		if err != nil {
@@ -308,6 +315,9 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 		if err != nil {
 			return err
 		}
+
+		c.log.Info("Deleting bucket on single s3 backend", "backend name", cr.GetProviderConfigReference().Name)
+
 		_, err = s3Backend.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(cr.Name)})
 		if err != nil {
 			return errors.Wrap(err, errDeleteBucket)
@@ -322,6 +332,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 		return errors.New(errNoS3BackendsStored)
 	}
 
+	c.log.Info("Deleting bucket on all available s3 backends")
 	for _, client := range c.backendStore.GetAllBackends() {
 		_, err := client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(cr.Name)})
 		if err != nil {

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -118,7 +118,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	return &external{backendStore: c.backendStore.GetBackendStore()}, nil
+	return &external{backendStore: c.backendStore.GetBackendStore(), log: c.log}, nil
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an

--- a/internal/controller/bucket/bucket.go
+++ b/internal/controller/bucket/bucket.go
@@ -113,7 +113,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	return &external{backendStore: c.backendStore.GeBackendStore()}, nil
+	return &external{backendStore: c.backendStore.GetBackendStore()}, nil
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an

--- a/internal/controller/bucket/bucket_test.go
+++ b/internal/controller/bucket/bucket_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/crossplane/provider-ceph/apis/provider-ceph/v1alpha1"
+	"github.com/crossplane/provider-ceph/internal/backendstore"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing
@@ -46,7 +47,7 @@ func TestObserve(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		s3Backends s3Backends
+		backendStore *backendstore.BackendStore
 	}
 
 	type args struct {
@@ -65,6 +66,9 @@ func TestObserve(t *testing.T) {
 		want   want
 	}{
 		"Invalid managed resource": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: unexpectedItem,
 			},
@@ -73,6 +77,9 @@ func TestObserve(t *testing.T) {
 			},
 		},
 		"S3 backend reference does not exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{
 					Spec: v1alpha1.BucketSpec{
@@ -89,6 +96,9 @@ func TestObserve(t *testing.T) {
 			},
 		},
 		"S3 backend not referenced and none exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{},
 			},
@@ -102,7 +112,7 @@ func TestObserve(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			e := external{s3Backends: tc.fields.s3Backends}
+			e := external{backendStore: tc.fields.backendStore}
 			got, err := e.Observe(context.Background(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -118,7 +128,7 @@ func TestCreate(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		s3Backends s3Backends
+		backendStore *backendstore.BackendStore
 	}
 
 	type args struct {
@@ -137,6 +147,9 @@ func TestCreate(t *testing.T) {
 		want   want
 	}{
 		"Invalid managed resource": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: unexpectedItem,
 			},
@@ -145,6 +158,9 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		"S3 backend reference does not exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{
 					Spec: v1alpha1.BucketSpec{
@@ -161,6 +177,9 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		"S3 backend not referenced and none exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{},
 			},
@@ -174,7 +193,7 @@ func TestCreate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			e := external{s3Backends: tc.fields.s3Backends}
+			e := external{backendStore: tc.fields.backendStore}
 			got, err := e.Create(context.Background(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Create(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -190,7 +209,7 @@ func TestDelete(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		s3Backends s3Backends
+		backendStore *backendstore.BackendStore
 	}
 
 	type args struct {
@@ -208,6 +227,9 @@ func TestDelete(t *testing.T) {
 		want   want
 	}{
 		"Invalid managed resource": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: unexpectedItem,
 			},
@@ -216,6 +238,9 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		"S3 backend reference does not exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{
 					Spec: v1alpha1.BucketSpec{
@@ -232,6 +257,9 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		"S3 backend not referenced and none exist": {
+			fields: fields{
+				backendStore: backendstore.NewBackendStore(),
+			},
 			args: args{
 				mg: &v1alpha1.Bucket{},
 			},
@@ -245,7 +273,7 @@ func TestDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			e := external{s3Backends: tc.fields.s3Backends}
+			e := external{backendStore: tc.fields.backendStore}
 			err := e.Delete(context.Background(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Delete(...): -want error, +got error:\n%s\n", tc.reason, diff)

--- a/internal/controller/ceph.go
+++ b/internal/controller/ceph.go
@@ -20,18 +20,19 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/crossplane/provider-ceph/internal/backendstore"
 	"github.com/crossplane/provider-ceph/internal/controller/bucket"
 	"github.com/crossplane/provider-ceph/internal/controller/config"
 )
 
 // Setup creates all Ceph controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options, *backendstore.BackendStore) error{
 		config.Setup,
 		bucket.Setup,
 	} {
-		if err := setup(mgr, o); err != nil {
+		if err := setup(mgr, o, s); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -34,7 +34,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane/provider-ceph/apis/v1alpha1"
 	apisv1alpha1 "github.com/crossplane/provider-ceph/apis/v1alpha1"
 	"github.com/crossplane/provider-ceph/internal/backendstore"
 	s3internal "github.com/crossplane/provider-ceph/internal/s3"
@@ -51,8 +50,8 @@ func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore)
 	name := providerconfig.ControllerName(apisv1alpha1.ProviderConfigGroupKind)
 
 	of := resource.ProviderConfigKinds{
-		Config:    v1alpha1.ProviderConfigGroupVersionKind,
-		UsageList: v1alpha1.ProviderConfigUsageListGroupVersionKind,
+		Config:    apisv1alpha1.ProviderConfigGroupVersionKind,
+		UsageList: apisv1alpha1.ProviderConfigUsageListGroupVersionKind,
 	}
 
 	// Add an 'internal' controller to the manager for the ProviderConfig.
@@ -68,8 +67,8 @@ func Setup(mgr ctrl.Manager, o controller.Options, s *backendstore.BackendStore)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
-		For(&v1alpha1.ProviderConfig{}).
-		Watches(&source.Kind{Type: &v1alpha1.ProviderConfigUsage{}}, &resource.EnqueueRequestForProviderConfig{}).
+		For(&apisv1alpha1.ProviderConfig{}).
+		Watches(&source.Kind{Type: &apisv1alpha1.ProviderConfigUsage{}}, &resource.EnqueueRequestForProviderConfig{}).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }
 


### PR DESCRIPTION
- Add reconciler for ProviderConfig so that entries in BackendStore can be managed on ProviderConfig reconciles.
- Do create and delete to backends in go routines.
- Some code tidy up and modularisation of larger functions.